### PR TITLE
Accept `TARGET` override as argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         run: ./setup-cli/assert/not-installed.sh
         shell: bash
 
-      - run: curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/${{ github.sha }}/install.sh | sh
+      - run: curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh | sh
         shell: bash
 
       - run: databricks version
@@ -189,6 +189,21 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: ./setup-cli/assert/path.sh /c/Windows/databricks
 
+      - run: curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh | sh -s ~/.local/bin
+        shell: bash
+
+      - run: PATH="$HOME/.local/bin:$PATH" databricks version
+        shell: bash
+
+      - name: Assert the version of the CLI installed
+        run: PATH="$HOME/.local/bin:$PATH" ./setup-cli/assert/version.sh $(cat ./setup-cli/VERSION)
+        shell: bash
+
+      - name: Assert installation path is ~/.local/bin for non-windows platforms
+        run: ./setup-cli/assert/path.sh ~/.local/bin/databricks
+        if: matrix.os != 'windows-latest'
+        shell: bash
+
   curl-dbr:
     # All DBR images are built on top of Ubuntu
     runs-on: ubuntu-latest
@@ -206,7 +221,7 @@ jobs:
         run: ./setup-cli/assert/not-installed.sh
         shell: bash
 
-      - run: curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/${{ github.sha }}/install.sh | sh
+      - run: curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh | sh
         shell: bash
         env:
           DATABRICKS_RUNTIME_VERSION: value-does-not-matter

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,11 @@ MINGW64_NT)
     ;;
 esac
 
+# Check for a command-line argument for the target directory
+if [ "$#" -gt 0 ]; then
+    TARGET="$1"
+fi
+
 # Set target to ~/bin if DATABRICKS_RUNTIME_VERSION environment variable is set.
 if [ -n "$DATABRICKS_RUNTIME_VERSION" ]; then
     # Set the installation target to ~/bin when run on DBR
@@ -56,6 +61,9 @@ arm64|aarch64)
     exit 1
     ;;
 esac
+
+# Create the target directory if it does not exist
+mkdir -p "$TARGET"
 
 # Make sure the target directory is writable.
 if [ ! -w "$TARGET" ]; then


### PR DESCRIPTION
Useful for local installation like `~/.local/bin`

`curl -fsSL
https://raw.githubusercontent.com/databricks/setup-cli/v${VERSION}/install.sh | sh -s ~/.local/bin`